### PR TITLE
tested /status route successfully

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -107,16 +107,24 @@ app.use(
 app.get('/status', async (req, res) => {
   try {
     const isListening = await web3.eth.net.isListening();
-    const networkType = await web3.eth.net.getNetworkType();
+
+    // web3.eth.net.getId() can return a BigInt in some versions of Web3.js
+    const networkId = await web3.eth.net.getId(); 
     const blockNumber = await web3.eth.getBlockNumber();
 
-    logger.info(`Status check successful: Listening=${isListening}, Network=${networkType}, Block=${blockNumber}`);
+    // Convert BigInt to string (or number) to avoid "Do not know how to serialize a BigInt" errors
+    const networkIdStr = networkId.toString();
+    const blockNumberStr = blockNumber.toString();
+
+    logger.info(
+      `Status check successful: Listening=${isListening}, NetworkID=${networkIdStr}, Block=${blockNumberStr}`
+    );
 
     res.json({
       status: 'success',
       isListening,
-      networkType,
-      blockNumber
+      networkId: networkIdStr,
+      blockNumber: blockNumberStr
     });
   } catch (error) {
     logger.error('Error during status check:', error.message);


### PR DESCRIPTION
# fix: Handle BigInt in /status route and prevent serialization errors

## Summary
- Replaced `getNetworkType()` (unsupported in Web3.js v4) with `getId()` and converted the return values (network ID, block number) from BigInt to strings.
- Addressed "Do not know how to serialize a BigInt" error by coercing BigInt responses to strings in the `/status` route.
- Retained all other functionality and logging logic.

## Details
- `/status` route:
  - Removed `web3.eth.net.getNetworkType()`, added `web3.eth.net.getId()`.
  - Converted `networkId` and `blockNumber` to strings before logging/returning them in JSON.
- Other routes (`/addVulnerability`, `/getVulnerability`) remain unchanged except for the new updates to Web3 initialization and logging.
- Ensured all environment variables are still validated and the application exits gracefully if any are missing.
- Logging framework (Winston + express-winston) remains for improved traceability.

## Reasoning
- Web3.js v4 can return BigInts for chain/network ID and block numbers.
- JavaScript’s default `JSON.stringify` (used by the server and logger) does not support BigInt, causing serialization failures.
- Converting to strings resolves this issue and maintains accurate display of values.